### PR TITLE
Return empty string for label if menu item is not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Find menu item by labels and return that with following properties:
 }
 ```
 
+> If the target is not found, label is returned as an empty string, all other properties are undefined.
+
 If the target is nested, it can be specified with variable length arguments.
 
 ex) File -> Open:

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -14,12 +14,18 @@ function findItem(menuItems: Array<MenuItem>, labels: string[]) {
 
 ipcMain.on('SPECTRON_MENU_ADDON/GET_MENU_ITEM', (e: Event, labels) => {
   const menuItem: MenuItem = findItem(Menu.getApplicationMenu().items, labels)
-  e.returnValue = new MenuItem({
-    checked: menuItem.checked,
-    enabled: menuItem.enabled,
-    label: menuItem.label,
-    visible: menuItem.visible
-  })
+  if (menuItem) {
+    e.returnValue = new MenuItem({
+      checked: menuItem.checked,
+      enabled: menuItem.enabled,
+      label: menuItem.label,
+      visible: menuItem.visible
+    })
+  } else {
+    e.returnValue = ({
+      label: ''
+    })
+  }
 })
 
 ipcMain.on('SPECTRON_MENU_ADDON/CLICK_MENU_ITEM', (e: Event, labels) => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -58,4 +58,13 @@ describe('Verify menu item status', () => {
     const menuItem = await menuAddon.getMenuItem('File', 'Open')
     expect(menuItem.enabled).to.equal(false)
   })
+
+  it('should return empty string if menu item does not exist', async () => {
+    expect(await app.client.getWindowCount()).to.equal(1)
+    const menuItem = await menuAddon.getMenuItem('File', 'Close')
+    expect(menuItem.label).to.equal('')
+    expect(menuItem.checked).to.equal(undefined)
+    expect(menuItem.enabled).to.equal(undefined)
+    expect(menuItem.visible).to.equal(undefined)
+  })
 })


### PR DESCRIPTION
Greetings,

I noticed in my testing that if a menu item did not exist, the test would crash and fire a dialog box. I could find no way to gracefully continue. 

The code I have added returns `{ label: '' }` if a menuitem is not found, all other values are left `undefined`.

I have added tests and a line in the readme.md for explanation.

Thanks for the consideration